### PR TITLE
Corregir la carga a Galaxy NG

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -7,8 +7,8 @@ namespace: byque
 # The name of the collection. Has the same character restrictions as 'namespace'
 name: local
 
-# The version of the collection. Must be compatible with semantic versioning
 version: 0.0.2
+# La versión de la colección. Debe ser compatible con versionamiento semántico
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -7,8 +7,8 @@ namespace: byque
 # The name of the collection. Has the same character restrictions as 'namespace'
 name: local
 
-version: 0.0.2
 # La versión de la colección. Debe ser compatible con versionamiento semántico
+version: 0.0.3
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,7 +1,7 @@
 ---
-# Collections must specify a minimum required ansible version to upload
-# to galaxy
 # requires_ansible: '>=2.9.10'
+# Las colecciones deben especificar la versión mínima de Ansible para cargarse
+# a Galaxy.
 
 # Content that Ansible needs to load from another location or that has
 # been deprecated/removed

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,7 +1,7 @@
 ---
-# requires_ansible: '>=2.9.10'
 # Las colecciones deben especificar la versión mínima de Ansible para cargarse
 # a Galaxy.
+requires_ansible: '>=2.18.6'
 
 # Content that Ansible needs to load from another location or that has
 # been deprecated/removed


### PR DESCRIPTION
# Descripción
Usando la interfaz web para cargar la colección v0.0.2 resultó en un error. Esta solicitud agrega los cambios necesarios para resolver ese error y también traduce los comentarios en el código fuente.

![imagen](https://github.com/user-attachments/assets/960235a3-6634-486e-8afc-7576ae9ab9d1)

Mensaje del registro de carga:

```sh
Importing with galaxy-importer 0.4.29 
Getting doc strings via ansible-doc 
Finding content inside collection 
Loading playbook mi_libro_de_jugadas.yml 
Loading role git 
Collection loading complete 

Finalizado
```